### PR TITLE
Fix unnecessary string output

### DIFF
--- a/create_db.py
+++ b/create_db.py
@@ -15,4 +15,3 @@ cursor.executescript(schema_sql)
 conn.commit()
 conn.close()
 
-str(db_path)


### PR DESCRIPTION
## Summary
- remove leftover `str(db_path)` statement from `create_db.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6868ff78ed98832581441580e23edb4d