### PR TITLE
Fix double stylesheet on tabs

### DIFF
--- a/main.py
+++ b/main.py
@@ -77,7 +77,6 @@ class MainWindow(QMainWindow):
                 color: #000;
             }
         """)
-        self.tabs.setStyleSheet(""" /* identico */ """)
         self.tabs.addTab(self._create_caricamento_tab(), "1. Caricamento")
         self.tabs.addTab(self._create_somministrazione_tab(), "2. Somministrazione")
 


### PR DESCRIPTION
## Summary
- remove second `setStyleSheet` call on the tab widget

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_686900a1d4848325a3378ef20613bade