### PR TITLE
Update schema with additional tables and columns

### DIFF
--- a/postgres-init.sql
+++ b/postgres-init.sql
@@ -1,17 +1,83 @@
-CREATE TABLE IF NOT EXISTS movement (
+CREATE TABLE IF NOT EXISTS ward (
     id SERIAL PRIMARY KEY,
-    inventory_id INTEGER,
-    change INTEGER NOT NULL,
-    reason TEXT,
-    ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    staff_id INTEGER
+    name TEXT NOT NULL UNIQUE
 );
 
-CREATE SCHEMA IF NOT EXISTS drawer;
-CREATE TABLE IF NOT EXISTS drawer.state (
-    drawer_id INTEGER PRIMARY KEY,
-    state TEXT NOT NULL,
-    ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+CREATE TABLE IF NOT EXISTS cart (
+    id SERIAL PRIMARY KEY,
+    ward_id INTEGER REFERENCES ward(id),
+    name TEXT NOT NULL,
+    label TEXT,
+    model TEXT,
+    serial_no TEXT
+);
+
+CREATE TABLE IF NOT EXISTS drawer_state (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE
+);
+
+CREATE TABLE IF NOT EXISTS drawer (
+    id SERIAL PRIMARY KEY,
+    cart_id INTEGER NOT NULL REFERENCES cart(id),
+    number INTEGER NOT NULL,
+    label TEXT,
+    state_id INTEGER REFERENCES drawer_state(id)
+);
+
+CREATE TABLE IF NOT EXISTS compartment (
+    id SERIAL PRIMARY KEY,
+    drawer_id INTEGER NOT NULL REFERENCES drawer(id),
+    number INTEGER NOT NULL,
+    label TEXT
+);
+
+CREATE TABLE IF NOT EXISTS drug_master (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,
+    form TEXT,
+    strength TEXT,
+    manufacturer TEXT,
+    last_updated TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS batch (
+    id SERIAL PRIMARY KEY,
+    drug_id INTEGER NOT NULL REFERENCES drug_master(id),
+    code TEXT,
+    expiry DATE,
+    batch_number TEXT,
+    mfg_date DATE,
+    exp_date DATE
+);
+
+CREATE TABLE IF NOT EXISTS inventory (
+    compartment_id INTEGER NOT NULL REFERENCES compartment(id),
+    drug_code INTEGER NOT NULL REFERENCES drug_master(id),
+    batch_id INTEGER NOT NULL REFERENCES batch(id),
+    quantity INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (compartment_id, drug_code, batch_id)
+);
+
+CREATE TABLE IF NOT EXISTS staff (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    username TEXT UNIQUE,
+    password TEXT,
+    badge TEXT UNIQUE
+);
+
+CREATE TABLE IF NOT EXISTS movement (
+    id SERIAL PRIMARY KEY,
+    movement_type TEXT NOT NULL,
+    compartment_id INTEGER,
+    drug_code INTEGER,
+    batch_id INTEGER,
+    qty INTEGER NOT NULL,
+    operator_id INTEGER REFERENCES staff(id),
+    timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (compartment_id, drug_code, batch_id)
+        REFERENCES inventory (compartment_id, drug_code, batch_id)
 );
 
 CREATE TABLE IF NOT EXISTS mqtt_outbox (
@@ -19,5 +85,13 @@ CREATE TABLE IF NOT EXISTS mqtt_outbox (
     topic TEXT NOT NULL,
     payload TEXT NOT NULL,
     sent BOOLEAN DEFAULT FALSE,
+    ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS cart_location (
+    id SERIAL PRIMARY KEY,
+    cart_id INTEGER NOT NULL REFERENCES cart(id),
+    x REAL,
+    y REAL,
     ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );

--- a/schema.sql
+++ b/schema.sql
@@ -5,6 +5,7 @@ DROP TABLE IF EXISTS inventory;
 DROP TABLE IF EXISTS batch;
 DROP TABLE IF EXISTS drug_master;
 DROP TABLE IF EXISTS compartment;
+DROP TABLE IF EXISTS drawer_state;
 DROP TABLE IF EXISTS drawer;
 DROP TABLE IF EXISTS cart;
 DROP TABLE IF EXISTS ward;
@@ -19,26 +20,42 @@ CREATE TABLE cart (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     ward_id INTEGER,
     name TEXT NOT NULL,
+    label TEXT,
+    model TEXT,
+    serial_no TEXT,
     FOREIGN KEY (ward_id) REFERENCES ward(id)
+);
+
+CREATE TABLE drawer_state (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL UNIQUE
 );
 
 CREATE TABLE drawer (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     cart_id INTEGER NOT NULL,
     number INTEGER NOT NULL,
-    FOREIGN KEY (cart_id) REFERENCES cart(id)
+    label TEXT,
+    state_id INTEGER,
+    FOREIGN KEY (cart_id) REFERENCES cart(id),
+    FOREIGN KEY (state_id) REFERENCES drawer_state(id)
 );
 
 CREATE TABLE compartment (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     drawer_id INTEGER NOT NULL,
     number INTEGER NOT NULL,
+    label TEXT,
     FOREIGN KEY (drawer_id) REFERENCES drawer(id)
 );
 
 CREATE TABLE drug_master (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
-    name TEXT NOT NULL UNIQUE
+    name TEXT NOT NULL UNIQUE,
+    form TEXT,
+    strength TEXT,
+    manufacturer TEXT,
+    last_updated DATETIME
 );
 
 CREATE TABLE batch (
@@ -46,28 +63,35 @@ CREATE TABLE batch (
     drug_id INTEGER NOT NULL,
     code TEXT,
     expiry DATE,
+    batch_number TEXT,
+    mfg_date DATE,
+    exp_date DATE,
     FOREIGN KEY (drug_id) REFERENCES drug_master(id)
 );
 
 CREATE TABLE inventory (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    batch_id INTEGER NOT NULL,
     compartment_id INTEGER NOT NULL,
+    drug_code INTEGER NOT NULL,
+    batch_id INTEGER NOT NULL,
     quantity INTEGER NOT NULL DEFAULT 0,
-    UNIQUE(batch_id, compartment_id),
-    FOREIGN KEY (batch_id) REFERENCES batch(id),
-    FOREIGN KEY (compartment_id) REFERENCES compartment(id)
+    PRIMARY KEY (compartment_id, drug_code, batch_id),
+    FOREIGN KEY (compartment_id) REFERENCES compartment(id),
+    FOREIGN KEY (drug_code) REFERENCES drug_master(id),
+    FOREIGN KEY (batch_id) REFERENCES batch(id)
 );
 
 CREATE TABLE movement (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
-    inventory_id INTEGER NOT NULL,
-    change INTEGER NOT NULL,
-    reason TEXT,
-    ts DATETIME DEFAULT CURRENT_TIMESTAMP,
-    staff_id INTEGER,
-    FOREIGN KEY (inventory_id) REFERENCES inventory(id),
-    FOREIGN KEY (staff_id) REFERENCES staff(id)
+    movement_type TEXT NOT NULL,
+    compartment_id INTEGER,
+    drug_code INTEGER,
+    batch_id INTEGER,
+    qty INTEGER NOT NULL,
+    operator_id INTEGER,
+    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (compartment_id, drug_code, batch_id)
+        REFERENCES inventory(compartment_id, drug_code, batch_id),
+    FOREIGN KEY (operator_id) REFERENCES staff(id)
 );
 
 CREATE TABLE staff (
@@ -96,18 +120,28 @@ CREATE TABLE cart_location (
 );
 
 -- Default data
-INSERT INTO cart (id, name) VALUES (1, 'Cart 1');
+INSERT INTO cart (id, name, label, model, serial_no) VALUES
+    (1, 'Cart 1', 'Cart 1', 'Model A', 'SN001');
 INSERT INTO ward (id, name) VALUES (1, 'Default Ward');
 UPDATE cart SET ward_id = 1 WHERE id = 1;
 INSERT INTO staff (name, username, password, badge) VALUES ('Admin', 'admin', 'admin', '0001');
 
--- Create drawers and compartments for cart 1
-INSERT INTO drawer (cart_id, number) VALUES
-    (1, 1),(1, 2),(1, 3),(1, 4),(1, 5);
+INSERT INTO drawer_state (id, name) VALUES
+    (1, 'closed'),
+    (2, 'open'),
+    (3, 'locked');
 
-INSERT INTO compartment (drawer_id, number) VALUES
-    (1,1),(1,2),(1,3),(1,4),(1,5),(1,6),
-    (2,1),(2,2),(2,3),(2,4),(2,5),(2,6),
-    (3,1),(3,2),(3,3),(3,4),(3,5),(3,6),
-    (4,1),(4,2),(4,3),(4,4),(4,5),(4,6),
-    (5,1),(5,2),(5,3),(5,4),(5,5),(5,6);
+-- Create drawers and compartments for cart 1
+INSERT INTO drawer (cart_id, number, label) VALUES
+    (1, 1, 'Drawer 1'),
+    (1, 2, 'Drawer 2'),
+    (1, 3, 'Drawer 3'),
+    (1, 4, 'Drawer 4'),
+    (1, 5, 'Drawer 5');
+
+INSERT INTO compartment (drawer_id, number, label) VALUES
+    (1,1,'C1-1'),(1,2,'C1-2'),(1,3,'C1-3'),(1,4,'C1-4'),(1,5,'C1-5'),(1,6,'C1-6'),
+    (2,1,'C2-1'),(2,2,'C2-2'),(2,3,'C2-3'),(2,4,'C2-4'),(2,5,'C2-5'),(2,6,'C2-6'),
+    (3,1,'C3-1'),(3,2,'C3-2'),(3,3,'C3-3'),(3,4,'C3-4'),(3,5,'C3-5'),(3,6,'C3-6'),
+    (4,1,'C4-1'),(4,2,'C4-2'),(4,3,'C4-3'),(4,4,'C4-4'),(4,5,'C4-5'),(4,6,'C4-6'),
+    (5,1,'C5-1'),(5,2,'C5-2'),(5,3,'C5-3'),(5,4,'C5-4'),(5,5,'C5-5'),(5,6,'C5-6');


### PR DESCRIPTION
## Summary
- extend SQL schema with cart, drawer, drug, batch and movement details
- recreate inventory table with composite primary key
- include new enumeration of drawer states and default data
- expand Postgres initialization script to match new schema

## Testing
- `python -m py_compile main.py cart_event_consumer.py cart_sync_service.py create_db.py`
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_68690e18a9288325a7926ed93a32ea1a