### PR TITLE
Switch services to SQLite

### DIFF
--- a/.env
+++ b/.env
@@ -1,9 +1,3 @@
-DB_HOST=db
-DB_PORT=5432
-DB_NAME=cart
-DB_USER=cart
-DB_PASSWORD=cart
-
 MQTT_HOST=mosquitto
 MQTT_PORT=1883
 CENTRAL_MQTT_HOST=mosquitto

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,24 +20,11 @@ services:
     ports:
       - "1883:1883"
 
-  db:
-    image: postgres:16
-    environment:
-      POSTGRES_DB: cart
-      POSTGRES_USER: cart
-      POSTGRES_PASSWORD: cart
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
-      - ./postgres-init.sql:/docker-entrypoint-initdb.d/init.sql
-    ports:
-      - "5432:5432"
-
   cart_consumer:
     build:
       context: .
       dockerfile: services/Dockerfile
     depends_on:
-      - db
       - mosquitto
     env_file:
       - .env
@@ -47,25 +34,9 @@ services:
     build:
       context: .
       dockerfile: services/Dockerfile
-    depends_on:
-      - db
     env_file:
       - .env
     command: python cart_sync_service.py
 
-  pgadmin:
-    image: dpage/pgadmin4
-    environment:
-      PGADMIN_DEFAULT_EMAIL: admin@admin.com
-      PGADMIN_DEFAULT_PASSWORD: admin
-    ports:
-      - "8080:80"
-    volumes:
-      - pgadmin_data:/var/lib/pgadmin
-    depends_on:
-      - db
-
 volumes:
   mosquitto_data:
-  postgres_data:
-  pgadmin_data:

--- a/schema.sql
+++ b/schema.sql
@@ -1,5 +1,5 @@
 DROP TABLE IF EXISTS cart_location;
-DROP TABLE IF EXISTS drawer_state;
+DROP TABLE IF EXISTS drawer_state_master;
 DROP TABLE IF EXISTS mqtt_outbox;
 DROP TABLE IF EXISTS movement;
 DROP TABLE IF EXISTS inventory;
@@ -27,7 +27,7 @@ CREATE TABLE cart (
     FOREIGN KEY (ward_id) REFERENCES ward(id)
 );
 
-CREATE TABLE drawer_state (
+CREATE TABLE drawer_state_master (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     name TEXT NOT NULL UNIQUE
 );
@@ -39,12 +39,13 @@ CREATE TABLE drawer (
     label TEXT,
     state_id INTEGER,
     FOREIGN KEY (cart_id) REFERENCES cart(id),
-    FOREIGN KEY (state_id) REFERENCES drawer_state(id)
+    FOREIGN KEY (state_id) REFERENCES drawer_state_master(id)
 );
 
 CREATE TABLE compartment (
     drawer_id INTEGER NOT NULL,
     number INTEGER NOT NULL,
+    label TEXT,
     PRIMARY KEY (drawer_id, number),
 
     FOREIGN KEY (drawer_id) REFERENCES drawer(id)
@@ -135,7 +136,7 @@ INSERT INTO ward (id, name) VALUES (1, 'Default Ward');
 UPDATE cart SET ward_id = 1 WHERE id = 1;
 INSERT INTO staff (name, username, password, badge) VALUES ('Admin', 'admin', 'admin', '0001');
 
-INSERT INTO drawer_state (id, name) VALUES
+INSERT INTO drawer_state_master (id, name) VALUES
     (1, 'closed'),
     (2, 'open'),
     (3, 'locked');
@@ -145,12 +146,6 @@ INSERT INTO drawer_state (id, name) VALUES
 INSERT INTO drawer (cart_id, number) VALUES
     (1, 1),(1, 2),(1, 3),(1, 4),(1, 5);
 
-INSERT INTO compartment (drawer_id, number) VALUES
-    (1,1),(1,2),(1,3),(1,4),(1,5),(1,6),
-    (2,1),(2,2),(2,3),(2,4),(2,5),(2,6),
-    (3,1),(3,2),(3,3),(3,4),(3,5),(3,6),
-    (4,1),(4,2),(4,3),(4,4),(4,5),(4,6),
-    (5,1),(5,2),(5,3),(5,4),(5,5),(5,6);
 
 -- Aggiorna la tabella inventory ad ogni inserimento in movement
 CREATE TRIGGER movement_inventory_update

--- a/services/requirements.txt
+++ b/services/requirements.txt
@@ -1,3 +1,2 @@
 paho-mqtt
-psycopg2-binary
 python-dotenv


### PR DESCRIPTION
## Summary
- drop Postgres services
- use SQLite for MQTT consumer and sync scripts
- clean up example `.env`
- fix DB schema for SQLite creation

## Testing
- `python -m py_compile cart_event_consumer.py cart_sync_service.py main.py create_db.py`


------
https://chatgpt.com/codex/tasks/task_e_686a11af208c8325896594955dc85f09